### PR TITLE
Add shopping cart persistence and CRUD API

### DIFF
--- a/ai/agentic-pipeline/turns/3/adr.md
+++ b/ai/agentic-pipeline/turns/3/adr.md
@@ -1,0 +1,14 @@
+# ADR 3: TypeORM Entity Model and Data Source Integration
+
+**Status**: Accepted
+
+**Date**: 2025-09-30
+
+## Context
+The project required an ORM layer that maps the previously defined shopping cart database schema to NestJS services, enabling transactional CRUD operations, migrations, and CLI tooling. Configuration needed to remain environment-driven and aligned with project conventions.
+
+## Decision
+Adopt TypeORM entities for the shopping cart, item, and discount tables, applying numeric transformers for currency fields and cascade relationships for child records. Configure a shared `AppDataSource` with SnakeNamingStrategy, environment loading from `ai/context/.env`, and register it through Nest's `TypeOrmModule`. Provide CLI scripts and a baseline migration to keep the ORM schema authoritative.
+
+## Consequences
+NestJS modules and services can inject repositories for domain persistence without manual query wiring. Migrations and connectivity checks run via repeatable npm scripts, and configuration validation ensures required database variables exist. Future features can reuse the entity classes and data source for additional queries and transactional operations.

--- a/ai/agentic-pipeline/turns/3/changelog.md
+++ b/ai/agentic-pipeline/turns/3/changelog.md
@@ -1,0 +1,20 @@
+# Turn: 3 – 2025-09-30T23:55:39Z
+
+## prompt
+execute turn 3 and turn 4
+
+#### Task
+- TASK 07 - Create Domain Entities
+- TASK 08 - Create TypeORM Configuration
+
+#### Changes
+- Modeled shopping cart, item, and discount aggregates as TypeORM entities with numeric transformers and relational metadata.
+- Introduced a dedicated DataSource, migration, and validation script to manage database connectivity via environment variables.
+- Extended configuration and application bootstrap to load new database settings and register the shopping cart persistence layer.
+- Added TypeORM CLI scripts and dependencies for migration creation, execution, and validation.
+
+#### Tools Executed
+- (none)
+
+#### Tests
+- (not run – database connectivity tooling only)

--- a/ai/agentic-pipeline/turns/3/manifest.json
+++ b/ai/agentic-pipeline/turns/3/manifest.json
@@ -1,0 +1,31 @@
+{
+  "turnId": 3,
+  "timestampUtc": "2025-09-30T23:55:39Z",
+  "task": {
+    "name": "Turn 3 domain persistence setup",
+    "inputs": [
+      "TASK 07 - Create Domain Entities",
+      "TASK 08 - Create TypeORM Configuration"
+    ]
+  },
+  "changes": {
+    "added": [
+      "api/src/common/database/column-numeric.transformer.ts",
+      "api/src/shopping-cart/entities/shopping-cart.entity.ts",
+      "api/src/shopping-cart/entities/shopping-cart-item.entity.ts",
+      "api/src/shopping-cart/entities/shopping-cart-discount.entity.ts",
+      "api/src/database/data-source.ts",
+      "api/src/database/validate-connection.ts",
+      "api/src/migrations/1714512000000-CreateShoppingCartSchema.ts"
+    ],
+    "modified": [
+      "api/package.json",
+      "api/src/app.module.ts",
+      "api/src/config/configuration.ts",
+      "api/src/config/validation.ts"
+    ]
+  },
+  "tests": {
+    "commands": []
+  }
+}

--- a/ai/agentic-pipeline/turns/3/session_context_values.md
+++ b/ai/agentic-pipeline/turns/3/session_context_values.md
@@ -1,0 +1,9 @@
+# Session Context Values
+
+- sandbox_base_directory: workspace
+- target_project: codex-shopping-cart
+- project_context: codex-shopping-cart/ai/context
+- application_implementation_pattern: full-stack-app-nextjs-nestjs
+- turn_task: Execute Turn 3 API tasks (07–08)
+- turn_id: 3
+- timestamp_utc: 2025-09-30T23:55:39Z

--- a/ai/agentic-pipeline/turns/4/adr.md
+++ b/ai/agentic-pipeline/turns/4/adr.md
@@ -1,0 +1,14 @@
+# ADR 4: Shopping Cart API Surface and Error Handling
+
+**Status**: Accepted
+
+**Date**: 2025-09-30
+
+## Context
+With persistence in place, the service needed HTTP endpoints, validation, and documented contracts so that clients can manage shopping carts reliably. Responses should return consistent error payloads and expose an OpenAPI definition for integration testing.
+
+## Decision
+Implement a dedicated `ShoppingCartController` backed by a transactional `ShoppingCartService` that materializes DTOs for creation, updates, and responses. Enable Nest's global `ValidationPipe` with whitelist and 422 semantics, add a custom `HttpExceptionFilter` producing Problem Detail envelopes, and surface Swagger UI plus JSON/YAML specs at `/api/docs` and `/api/openapi.*`.
+
+## Consequences
+Clients receive validated, well-documented CRUD endpoints with predictable error shapes, while automated suites can consume the OpenAPI document. Supertest e2e tests and .http scripts now exercise the full cart lifecycle, providing regression coverage tied to the live persistence layer.

--- a/ai/agentic-pipeline/turns/4/changelog.md
+++ b/ai/agentic-pipeline/turns/4/changelog.md
@@ -1,0 +1,21 @@
+# Turn: 4 – 2025-09-30T23:55:40Z
+
+## prompt
+execute turn 3 and turn 4
+
+#### Task
+- TASK 09 – Implement Domain CRUD Endpoints
+- Task 10 – Global Validation Pipe & Error Handling
+- Task 11 – End-to-End Tests with Supertest
+
+#### Changes
+- Delivered shopping cart DTOs, service orchestration, and controller routes covering full CRUD operations with Swagger metadata.
+- Registered global validation and an HttpExceptionFilter producing RFC 7807-style envelopes alongside OpenAPI documentation endpoints.
+- Authored Supertest e2e coverage and a .http smoke suite exercising cart lifecycle and OpenAPI discovery paths.
+- Expanded application bootstrap to publish `/api/docs`, `/api/openapi.json`, and `/api/openapi.yaml` backed by YAML serialization.
+
+#### Tools Executed
+- (none)
+
+#### Tests
+- (not run – Postgres dependency unavailable in container)

--- a/ai/agentic-pipeline/turns/4/manifest.json
+++ b/ai/agentic-pipeline/turns/4/manifest.json
@@ -1,0 +1,34 @@
+{
+  "turnId": 4,
+  "timestampUtc": "2025-09-30T23:55:40Z",
+  "task": {
+    "name": "Turn 4 shopping cart API delivery",
+    "inputs": [
+      "TASK 09 – Implement Domain CRUD Endpoints",
+      "Task 10 – Global Validation Pipe & Error Handling",
+      "Task 11 – End-to-End Tests with Supertest"
+    ]
+  },
+  "changes": {
+    "added": [
+      "api/src/shopping-cart/dto/shopping-cart-item.dto.ts",
+      "api/src/shopping-cart/dto/shopping-cart-discount.dto.ts",
+      "api/src/shopping-cart/dto/shopping-cart.dto.ts",
+      "api/src/shopping-cart/services/shopping-cart.service.ts",
+      "api/src/shopping-cart/shopping-cart.controller.ts",
+      "api/src/shopping-cart/shopping-cart.module.ts",
+      "api/src/common/http/problem-detail.ts",
+      "api/src/common/http/http-exception.filter.ts",
+      "api/test/e2e/shopping-cart.e2e-spec.ts",
+      "api/e2e/shopping-carts.http"
+    ],
+    "modified": [
+      "api/package.json",
+      "api/src/app.module.ts",
+      "api/src/main.ts"
+    ]
+  },
+  "tests": {
+    "commands": []
+  }
+}

--- a/ai/agentic-pipeline/turns/4/session_context_values.md
+++ b/ai/agentic-pipeline/turns/4/session_context_values.md
@@ -1,0 +1,9 @@
+# Session Context Values
+
+- sandbox_base_directory: workspace
+- target_project: codex-shopping-cart
+- project_context: codex-shopping-cart/ai/context
+- application_implementation_pattern: full-stack-app-nextjs-nestjs
+- turn_task: Execute Turn 4 API tasks (09–11)
+- turn_id: 4
+- timestamp_utc: 2025-09-30T23:55:40Z

--- a/ai/agentic-pipeline/turns/index.csv
+++ b/ai/agentic-pipeline/turns/index.csv
@@ -1,3 +1,5 @@
 turnId,timestampUtc,task,branch,tag,headAfter,testsPassed,testsFailed,coverageDeltaPct
 1,2025-09-30T23:31:16Z,Turn 1 API bootstrap,-,-,-,2,0,0
 2,2025-09-30T23:31:16Z,Turn 2 database enablement,-,-,-,0,0,0
+3,2025-09-30T23:55:39Z,Turn 3 domain persistence setup,-,-,-,0,0,0
+4,2025-09-30T23:55:40Z,Turn 4 shopping cart API delivery,-,-,-,0,0,0

--- a/api/e2e/shopping-carts.http
+++ b/api/e2e/shopping-carts.http
@@ -1,0 +1,65 @@
+# App: Shopping Cart
+# Package: api
+# File: e2e/shopping-carts.http
+# Version: 0.1.0
+# Turns: 4
+# Author: Codex Agent
+# Date: 2025-09-30T23:55:39Z
+# Description: REST client smoke tests covering shopping cart CRUD endpoints and OpenAPI contract discovery.
+
+### Create shopping cart
+POST http://localhost:3000/shopping-cart
+Content-Type: application/json
+Accept: application/json
+
+{
+  "userId": "11111111-2222-4333-8444-555555555555",
+  "items": [
+    {
+      "productId": "SKU-12345",
+      "name": "Wireless Mouse",
+      "quantity": 2,
+      "unitPrice": 19.99,
+      "currency": "USD"
+    }
+  ],
+  "discounts": [
+    {
+      "code": "FREESHIP",
+      "amount": 5.0
+    }
+  ],
+  "subtotal": 39.98,
+  "tax": 3.2,
+  "shipping": 4.99,
+  "total": 43.17,
+  "currency": "USD"
+}
+
+### List shopping carts
+GET http://localhost:3000/shopping-cart
+Accept: application/json
+
+### Fetch shopping cart by id
+# @prompt cartId Enter cart identifier returned from create response
+GET http://localhost:3000/shopping-cart/{{cartId}}
+Accept: application/json
+
+### Update shopping cart
+PUT http://localhost:3000/shopping-cart/{{cartId}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "tax": 3.5,
+  "shipping": 0,
+  "total": 42.48
+}
+
+### Delete shopping cart
+DELETE http://localhost:3000/shopping-cart/{{cartId}}
+Accept: application/json
+
+### Retrieve OpenAPI specification
+GET http://localhost:3000/api/openapi.json
+Accept: application/json

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,14 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:validate": "dotenv -e ../ai/context/.env -e .env -- ts-node src/database/validate-connection.ts",
+    "typeorm:migration:create": "dotenv -e ../ai/context/.env -e .env -- typeorm migration:create src/migrations/Manual",
+    "typeorm:migration:generate": "dotenv -e ../ai/context/.env -e .env -- typeorm migration:generate src/migrations/Auto -d src/database/data-source.ts",
+    "typeorm:migration:run": "dotenv -e ../ai/context/.env -e .env -- node --require ts-node/register ./node_modules/typeorm/cli.js migration:run -d src/database/data-source.ts",
+    "typeorm:migration:revert": "dotenv -e ../ai/context/.env -e .env -- node --require ts-node/register ./node_modules/typeorm/cli.js migration:revert -d src/database/data-source.ts",
+    "typeorm:migration:run:js": "dotenv -e ../ai/context/.env -e .env -- node ./node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",
+    "typeorm:migration:revert:js": "dotenv -e ../ai/context/.env -e .env -- node ./node_modules/typeorm/cli.js migration:revert -d dist/database/data-source.js"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",
@@ -30,11 +37,14 @@
     "axios": "^1.9.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "dotenv": "^16.4.5",
+    "joi": "^17.10.0",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "joi": "^17.10.0",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "typeorm-naming-strategies": "^2.0.0",
+    "yaml": "^2.6.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",
@@ -46,6 +56,7 @@
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",
+    "dotenv-cli": "^7.3.0",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -2,33 +2,62 @@
  * App: Shopping Cart
  * Package: api
  * File: app.module.ts
- * Version: 0.1.0
- * Turns: 1
+ * Version: 0.2.0
+ * Turns: 4
  * Author: Codex Agent
- * Date: 2025-09-30T23:31:16Z
+ * Date: 2025-09-30T23:55:39Z
  * Exports: AppModule
- * Description: Root application module wiring configuration, health endpoints, and structured logging middleware.
+ * Description: Root application module wiring configuration, health endpoints, logging, database connectivity, and domain modules.
  */
+import * as path from 'node:path';
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import configuration from './config/configuration';
 import { validationSchema } from './config/validation';
 import { HealthModule } from './health/health.module';
 import { RequestIdMiddleware } from './common/logging/request-id.middleware';
 import { JsonLogger } from './common/logging/json-logger.service';
 import { LoggingInterceptor } from './common/logging/logging.interceptor';
+import { ShoppingCartModule } from './shopping-cart/shopping-cart.module';
+import { HttpExceptionFilter } from './common/http/http-exception.filter';
+import { ShoppingCartEntity } from './shopping-cart/entities/shopping-cart.entity';
+import { ShoppingCartItemEntity } from './shopping-cart/entities/shopping-cart-item.entity';
+import { ShoppingCartDiscountEntity } from './shopping-cart/entities/shopping-cart-discount.entity';
+
+const CONTEXT_ENV = path.resolve(__dirname, '..', '..', 'ai', 'context', '.env');
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: ['.env'],
+      envFilePath: [CONTEXT_ENV, '.env'],
       load: [configuration],
       validationSchema,
     }),
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        host: config.get<string>('db.host'),
+        port: config.get<number>('db.port'),
+        username: config.get<string>('db.username'),
+        password: config.get<string>('db.password'),
+        database: config.get<string>('db.name'),
+        schema: config.get<string>('db.schema'),
+        ssl: config.get<boolean>('db.ssl') || undefined,
+        namingStrategy: new SnakeNamingStrategy(),
+        synchronize: false,
+        logging: false,
+        entities: [ShoppingCartEntity, ShoppingCartItemEntity, ShoppingCartDiscountEntity],
+        migrations: [path.join(__dirname, 'migrations', '*{.js,.ts}')],
+      }),
+    }),
     HealthModule,
+    ShoppingCartModule,
   ],
-  providers: [JsonLogger, LoggingInterceptor],
+  providers: [JsonLogger, LoggingInterceptor, HttpExceptionFilter],
   exports: [JsonLogger, LoggingInterceptor],
 })
 export class AppModule implements NestModule {

--- a/api/src/common/database/column-numeric.transformer.ts
+++ b/api/src/common/database/column-numeric.transformer.ts
@@ -1,0 +1,32 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: common/database/column-numeric.transformer.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ColumnNumericTransformer
+ * Description: TypeORM value transformer converting between numeric database strings and JavaScript numbers.
+ */
+import { ValueTransformer } from 'typeorm';
+
+export class ColumnNumericTransformer implements ValueTransformer {
+  to(value?: number | null): string | null | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    return value.toString();
+  }
+
+  from(value: string | null): number | null {
+    if (value === null) {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+}

--- a/api/src/common/http/http-exception.filter.ts
+++ b/api/src/common/http/http-exception.filter.ts
@@ -1,0 +1,73 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: common/http/http-exception.filter.ts
+ * Version: 0.1.0
+ * Turns: 4
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: HttpExceptionFilter
+ * Description: Global NestJS exception filter normalizing error responses into Problem Detail envelopes with structured logging.
+ */
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { JsonLogger } from '../logging/json-logger.service';
+import { ProblemDetail } from './problem-detail';
+
+@Injectable()
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  constructor(private readonly logger: JsonLogger) {}
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const problem = this.buildProblemDetail(exception, request);
+    this.logger.error('HTTP request failed', {
+      ...problem,
+      stack: exception instanceof Error ? exception.stack : undefined,
+    });
+
+    response.status(problem.statusCode).json(problem);
+  }
+
+  private buildProblemDetail(exception: unknown, request: Request): ProblemDetail {
+    const timestamp = new Date().toISOString();
+    const path = request.url;
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const response = exception.getResponse();
+      if (typeof response === 'string') {
+        return {
+          statusCode: status,
+          error: exception.name,
+          message: response,
+          path,
+          timestamp,
+        };
+      }
+
+      const body = response as Record<string, unknown>;
+      return {
+        statusCode: status,
+        error: (body.error as string) ?? exception.name,
+        message: (body.message as string | string[]) ?? exception.message,
+        path,
+        timestamp,
+        details: body.details ?? body.errors,
+      };
+    }
+
+    const message = exception instanceof Error ? exception.message : 'Internal server error';
+    return {
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      error: 'Internal Server Error',
+      message,
+      path,
+      timestamp,
+    };
+  }
+}

--- a/api/src/common/http/problem-detail.ts
+++ b/api/src/common/http/problem-detail.ts
@@ -1,0 +1,32 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: common/http/problem-detail.ts
+ * Version: 0.1.0
+ * Turns: 4
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ProblemDetail
+ * Description: Problem Details response contract describing standardized error payloads returned by the API.
+ */
+import { ApiPropertyOptional, ApiResponseProperty } from '@nestjs/swagger';
+
+export class ProblemDetail {
+  @ApiResponseProperty({ description: 'HTTP status code of the error', example: 400 })
+  statusCode!: number;
+
+  @ApiResponseProperty({ description: 'Short error summary', example: 'Bad Request' })
+  error!: string;
+
+  @ApiResponseProperty({ description: 'Human readable explanation of the problem' })
+  message!: string | string[];
+
+  @ApiResponseProperty({ description: 'Request path that triggered the error', example: '/shopping-cart/123' })
+  path!: string;
+
+  @ApiResponseProperty({ description: 'Timestamp indicating when the error occurred', example: '2025-09-30T23:31:16.000Z' })
+  timestamp!: string;
+
+  @ApiPropertyOptional({ description: 'Additional error details providing field level validation messages' })
+  details?: unknown;
+}

--- a/api/src/config/configuration.ts
+++ b/api/src/config/configuration.ts
@@ -1,13 +1,13 @@
 /**
  * App: Shopping Cart
  * Package: api
- * File: configuration.ts
- * Version: 0.1.0
- * Turns: 1
+ * File: config/configuration.ts
+ * Version: 0.2.0
+ * Turns: 4
  * Author: Codex Agent
- * Date: 2025-09-30T23:31:16Z
+ * Date: 2025-09-30T23:55:39Z
  * Exports: default
- * Description: Configuration factory providing strongly typed access to application and database settings.
+ * Description: Configuration factory providing strongly typed access to application, database, and logging settings.
  */
 export default () => ({
   app: {
@@ -18,8 +18,8 @@ export default () => ({
   db: {
     host: process.env.DATABASE_HOST,
     port: parseInt(process.env.DATABASE_PORT ?? '5432', 10),
-    user: process.env.DATABASE_USER,
-    pass: process.env.DATABASE_PASSWORD,
+    username: process.env.DATABASE_USERNAME,
+    password: process.env.DATABASE_PASSWORD,
     name: process.env.DATABASE_NAME,
     schema: process.env.DATABASE_SCHEMA ?? 'public',
     ssl: (process.env.DATABASE_SSL ?? 'false').toLowerCase() === 'true',

--- a/api/src/config/validation.ts
+++ b/api/src/config/validation.ts
@@ -1,33 +1,27 @@
 /**
  * App: Shopping Cart
  * Package: api
- * File: validation.ts
- * Version: 0.1.0
- * Turns: 1
+ * File: config/validation.ts
+ * Version: 0.2.0
+ * Turns: 4
  * Author: Codex Agent
- * Date: 2025-09-30T23:31:16Z
+ * Date: 2025-09-30T23:55:39Z
  * Exports: validationSchema
  * Description: Joi schema validating configuration required to run the API and supporting logging toggles.
  */
 import * as Joi from 'joi';
 
 export const validationSchema = Joi.object({
-  NODE_ENV: Joi.string()
-    .valid('development', 'test', 'production')
-    .default('development'),
+  NODE_ENV: Joi.string().valid('development', 'test', 'production').default('development'),
   APP_NAME: Joi.string().default('backend'),
   PORT: Joi.number().integer().min(1).max(65535).default(3000),
   DATABASE_HOST: Joi.string().hostname().required(),
   DATABASE_PORT: Joi.number().integer().min(1).max(65535).default(5432),
-  DATABASE_USER: Joi.string().required(),
+  DATABASE_USERNAME: Joi.string().required(),
   DATABASE_PASSWORD: Joi.string().allow('').required(),
   DATABASE_NAME: Joi.string().required(),
   DATABASE_SCHEMA: Joi.string().default('public'),
   DATABASE_SSL: Joi.boolean().truthy('true').falsy('false').default(false),
-  LOG_LEVEL: Joi.string()
-    .valid('error', 'warn', 'log', 'debug', 'verbose')
-    .default('log'),
-  LOG_FORMAT: Joi.string()
-    .valid('json', 'text')
-    .default('json'),
+  LOG_LEVEL: Joi.string().valid('error', 'warn', 'log', 'debug', 'verbose').default('log'),
+  LOG_FORMAT: Joi.string().valid('json', 'text').default('json'),
 });

--- a/api/src/database/data-source.ts
+++ b/api/src/database/data-source.ts
@@ -1,0 +1,39 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: database/data-source.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: AppDataSource
+ * Description: TypeORM DataSource configuration loading environment variables for CLI interactions and migrations.
+ */
+import 'reflect-metadata';
+import * as path from 'node:path';
+import * as dotenv from 'dotenv';
+import { DataSource } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { ShoppingCartEntity } from '../shopping-cart/entities/shopping-cart.entity';
+import { ShoppingCartItemEntity } from '../shopping-cart/entities/shopping-cart-item.entity';
+import { ShoppingCartDiscountEntity } from '../shopping-cart/entities/shopping-cart-discount.entity';
+
+const contextEnvPath = path.resolve(__dirname, '..', '..', 'ai', 'context', '.env');
+dotenv.config({ path: contextEnvPath });
+dotenv.config();
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DATABASE_HOST,
+  port: Number(process.env.DATABASE_PORT ?? 5432),
+  username: process.env.DATABASE_USERNAME,
+  password: process.env.DATABASE_PASSWORD,
+  database: process.env.DATABASE_NAME,
+  schema: process.env.DATABASE_SCHEMA,
+  ssl: (process.env.DATABASE_SSL ?? 'false').toLowerCase() === 'true' ? { rejectUnauthorized: false } : undefined,
+  synchronize: false,
+  logging: false,
+  namingStrategy: new SnakeNamingStrategy(),
+  entities: [ShoppingCartEntity, ShoppingCartItemEntity, ShoppingCartDiscountEntity],
+  migrations: [path.resolve(__dirname, 'migrations', '*{.ts,.js}'), path.resolve(__dirname, '..', 'migrations', '*{.ts,.js}')],
+});

--- a/api/src/database/validate-connection.ts
+++ b/api/src/database/validate-connection.ts
@@ -1,0 +1,25 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: database/validate-connection.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Description: Connectivity smoke-test script for the DataSource ensuring database credentials succeed.
+ */
+import { AppDataSource } from './data-source';
+
+(async () => {
+  try {
+    const dataSource = await AppDataSource.initialize();
+    await dataSource.query('SELECT 1');
+    await dataSource.destroy();
+    // eslint-disable-next-line no-console
+    console.log('DB connection OK');
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('DB connection failed', error);
+    process.exit(1);
+  }
+})();

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -2,20 +2,25 @@
  * App: Shopping Cart
  * Package: api
  * File: main.ts
- * Version: 0.1.0
- * Turns: 1
+ * Version: 0.2.0
+ * Turns: 4
  * Author: Codex Agent
- * Date: 2025-09-30T23:31:16Z
+ * Date: 2025-09-30T23:55:39Z
  * Exports: bootstrap
- * Description: Bootstraps the NestJS HTTP server with validated configuration and structured logging.
+ * Description: Bootstraps the NestJS HTTP server with validated configuration, structured logging, global validation, and OpenAPI docs.
  */
 import 'reflect-metadata';
-import { LogLevel, ValidationPipe } from '@nestjs/common';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { LogLevel, ValidationPipe, HttpStatus } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { stringify as toYaml } from 'yaml';
 import { AppModule } from './app.module';
 import { JsonLogger } from './common/logging/json-logger.service';
 import { LoggingInterceptor } from './common/logging/logging.interceptor';
+import { HttpExceptionFilter } from './common/http/http-exception.filter';
 
 const levelsOrder: LogLevel[] = ['error', 'warn', 'log', 'debug', 'verbose'];
 
@@ -39,16 +44,44 @@ async function bootstrap(): Promise<void> {
   const loggingInterceptor = app.get(LoggingInterceptor);
   app.useGlobalInterceptors(loggingInterceptor);
 
+  const exceptionFilter = app.get(HttpExceptionFilter);
+  app.useGlobalFilters(exceptionFilter);
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
       transform: true,
       forbidNonWhitelisted: true,
+      forbidUnknownValues: true,
+      transformOptions: { enableImplicitConversion: true },
+      errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
     }),
   );
 
   const config = app.get(ConfigService);
   const port = config.get<number>('app.port', 3000);
+
+  const packageJson = JSON.parse(
+    readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
+  ) as { version: string };
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Shopping Cart API')
+    .setDescription('REST API for managing shopping cart aggregates')
+    .setVersion(packageJson.version)
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, document);
+
+  const httpAdapter = app.getHttpAdapter();
+  httpAdapter.get('/api/openapi.json', (_req, res) => {
+    res.json(document);
+  });
+  httpAdapter.get('/api/openapi.yaml', (_req, res) => {
+    res.type('text/yaml').send(toYaml(document));
+  });
+
   await app.listen(port);
 }
 

--- a/api/src/migrations/1714512000000-CreateShoppingCartSchema.ts
+++ b/api/src/migrations/1714512000000-CreateShoppingCartSchema.ts
@@ -1,0 +1,102 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: migrations/1714512000000-CreateShoppingCartSchema.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Description: TypeORM migration creating shopping cart schema, tables, indexes, and supporting view.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateShoppingCartSchema1714512000000 implements MigrationInterface {
+  name = 'CreateShoppingCartSchema1714512000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE SCHEMA IF NOT EXISTS "shopping_cart"`);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "shopping_cart"."shopping_cart" (
+        "cart_id" uuid PRIMARY KEY,
+        "user_id" uuid NOT NULL,
+        "subtotal" numeric(12, 2) NOT NULL CHECK ("subtotal" >= 0),
+        "tax" numeric(12, 2) NOT NULL DEFAULT 0 CHECK ("tax" >= 0),
+        "shipping" numeric(12, 2) NOT NULL DEFAULT 0 CHECK ("shipping" >= 0),
+        "total" numeric(12, 2) NOT NULL CHECK ("total" >= 0),
+        "currency" char(3) NOT NULL,
+        "created_at" timestamptz NOT NULL DEFAULT NOW(),
+        "updated_at" timestamptz NOT NULL DEFAULT NOW(),
+        CONSTRAINT "ux_shopping_cart_user_id_cart_id" UNIQUE ("user_id", "cart_id")
+      )
+    `);
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "ix_shopping_cart_user_id" ON "shopping_cart"."shopping_cart" ("user_id")',
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "shopping_cart"."shopping_cart_item" (
+        "item_id" BIGSERIAL PRIMARY KEY,
+        "cart_id" uuid NOT NULL REFERENCES "shopping_cart"."shopping_cart" ("cart_id") ON DELETE CASCADE,
+        "product_id" varchar(100) NOT NULL,
+        "name" varchar(255) NOT NULL,
+        "quantity" integer NOT NULL CHECK ("quantity" >= 1),
+        "unit_price" numeric(12, 2) NOT NULL CHECK ("unit_price" >= 0),
+        "total_price" numeric(12, 2) NOT NULL CHECK ("total_price" >= 0),
+        "currency" char(3),
+        CONSTRAINT "ux_shopping_cart_item_cart_product" UNIQUE ("cart_id", "product_id")
+      )
+    `);
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "ix_shopping_cart_item_cart_id" ON "shopping_cart"."shopping_cart_item" ("cart_id")',
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "shopping_cart"."shopping_cart_discount" (
+        "discount_id" BIGSERIAL PRIMARY KEY,
+        "cart_id" uuid NOT NULL REFERENCES "shopping_cart"."shopping_cart" ("cart_id") ON DELETE CASCADE,
+        "code" varchar(64),
+        "amount" numeric(12, 2) NOT NULL CHECK ("amount" >= 0)
+      )
+    `);
+
+    await queryRunner.query(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "ux_shopping_cart_discount_code" ON "shopping_cart"."shopping_cart_discount" ("cart_id", "code") WHERE "code" IS NOT NULL',
+    );
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "ix_shopping_cart_discount_cart_id" ON "shopping_cart"."shopping_cart_discount" ("cart_id")',
+    );
+
+    await queryRunner.query(`
+      CREATE OR REPLACE VIEW "shopping_cart"."shopping_cart_overview" AS
+      SELECT
+        c.cart_id,
+        c.user_id,
+        c.currency,
+        c.total,
+        c.subtotal,
+        c.tax,
+        c.shipping,
+        COUNT(i.item_id) AS item_count,
+        COALESCE(SUM(i.total_price), 0) AS items_total,
+        COALESCE(SUM(d.amount), 0) AS discounts_total,
+        c.created_at,
+        c.updated_at
+      FROM "shopping_cart"."shopping_cart" c
+      LEFT JOIN "shopping_cart"."shopping_cart_item" i ON i.cart_id = c.cart_id
+      LEFT JOIN "shopping_cart"."shopping_cart_discount" d ON d.cart_id = c.cart_id
+      GROUP BY c.cart_id
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP VIEW IF EXISTS "shopping_cart"."shopping_cart_overview"');
+    await queryRunner.query('DROP TABLE IF EXISTS "shopping_cart"."shopping_cart_discount" CASCADE');
+    await queryRunner.query('DROP TABLE IF EXISTS "shopping_cart"."shopping_cart_item" CASCADE');
+    await queryRunner.query('DROP TABLE IF EXISTS "shopping_cart"."shopping_cart" CASCADE');
+    await queryRunner.query('DROP SCHEMA IF EXISTS "shopping_cart" CASCADE');
+  }
+}

--- a/api/src/shopping-cart/dto/shopping-cart-discount.dto.ts
+++ b/api/src/shopping-cart/dto/shopping-cart-discount.dto.ts
@@ -1,0 +1,44 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/dto/shopping-cart-discount.dto.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: CreateShoppingCartDiscountDto, UpdateShoppingCartDiscountDto, ShoppingCartDiscountDto
+ * Description: DTO models for cart discounts with validation constraints and OpenAPI metadata.
+ */
+import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsString, Length, Min } from 'class-validator';
+
+export class CreateShoppingCartDiscountDto {
+  @ApiPropertyOptional({ description: 'Discount or coupon code applied to the cart', example: 'FREESHIP' })
+  @IsOptional()
+  @IsString()
+  @Length(1, 64)
+  code?: string;
+
+  @ApiProperty({ description: 'Monetary amount of the discount', example: 5.0, minimum: 0 })
+  @Type(() => Number)
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  @Min(0)
+  amount!: number;
+}
+
+export class UpdateShoppingCartDiscountDto extends PartialType(CreateShoppingCartDiscountDto) {}
+
+export class ShoppingCartDiscountDto {
+  @ApiProperty({ description: 'Database identifier for the discount row', example: 7 })
+  discountId!: number;
+
+  @ApiPropertyOptional({ description: 'Discount or coupon code applied to the cart', example: 'FREESHIP' })
+  @IsOptional()
+  @IsString()
+  code?: string | null;
+
+  @ApiProperty({ description: 'Monetary amount of the discount', example: 5.0 })
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  amount!: number;
+}

--- a/api/src/shopping-cart/dto/shopping-cart-item.dto.ts
+++ b/api/src/shopping-cart/dto/shopping-cart-item.dto.ts
@@ -1,0 +1,94 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/dto/shopping-cart-item.dto.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: CreateShoppingCartItemDto, UpdateShoppingCartItemDto, ShoppingCartItemDto
+ * Description: DTO definitions describing shopping cart line items with validation rules and API annotations.
+ */
+import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Length,
+  Matches,
+  Min,
+} from 'class-validator';
+
+export class CreateShoppingCartItemDto {
+  @ApiProperty({ description: 'Product identifier within the catalog', example: 'SKU-12345' })
+  @IsString()
+  @IsNotEmpty()
+  productId!: string;
+
+  @ApiProperty({ description: 'Human readable product name', example: 'Wireless Mouse' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ description: 'Quantity of the product in the cart', example: 2, minimum: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+
+  @ApiProperty({ description: 'Unit price for the product', example: 19.99, minimum: 0 })
+  @Type(() => Number)
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  @Min(0)
+  unitPrice!: number;
+
+  @ApiPropertyOptional({ description: 'Currency for pricing in ISO 4217 format', example: 'USD', pattern: '^[A-Z]{3}$' })
+  @IsOptional()
+  @IsString()
+  @Length(3, 3)
+  @Matches(/^[A-Z]{3}$/)
+  currency?: string;
+
+  @ApiPropertyOptional({ description: 'Override total line price when provided', example: 39.98, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  @Min(0)
+  totalPrice?: number;
+}
+
+export class UpdateShoppingCartItemDto extends PartialType(CreateShoppingCartItemDto) {}
+
+export class ShoppingCartItemDto {
+  @ApiProperty({ description: 'Database identifier for the line item', example: 42 })
+  @IsInt()
+  itemId!: number;
+
+  @ApiProperty({ description: 'Product identifier within the catalog', example: 'SKU-12345' })
+  @IsString()
+  productId!: string;
+
+  @ApiProperty({ description: 'Human readable product name', example: 'Wireless Mouse' })
+  @IsString()
+  name!: string;
+
+  @ApiProperty({ description: 'Quantity of the product in the cart', example: 2 })
+  @IsInt()
+  quantity!: number;
+
+  @ApiProperty({ description: 'Unit price for the product', example: 19.99 })
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  unitPrice!: number;
+
+  @ApiProperty({ description: 'Total price for the line item', example: 39.98 })
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  totalPrice!: number;
+
+  @ApiPropertyOptional({ description: 'Currency for pricing in ISO 4217 format', example: 'USD' })
+  @IsOptional()
+  @IsString()
+  currency?: string | null;
+}

--- a/api/src/shopping-cart/dto/shopping-cart.dto.ts
+++ b/api/src/shopping-cart/dto/shopping-cart.dto.ts
@@ -1,0 +1,154 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/dto/shopping-cart.dto.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: CreateShoppingCartDto, UpdateShoppingCartDto, ResponseShoppingCartDto
+ * Description: DTOs for shopping cart aggregate operations including validation and OpenAPI metadata.
+ */
+import { ApiProperty, ApiPropertyOptional, ApiResponseProperty, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import {
+  CreateShoppingCartItemDto,
+  ShoppingCartItemDto,
+  UpdateShoppingCartItemDto,
+} from './shopping-cart-item.dto';
+import {
+  CreateShoppingCartDiscountDto,
+  ShoppingCartDiscountDto,
+  UpdateShoppingCartDiscountDto,
+} from './shopping-cart-discount.dto';
+
+export class CreateShoppingCartDto {
+  @ApiPropertyOptional({ description: 'Identifier for the cart', example: '3d5e67a5-0df5-4c08-9ad0-5f7c1c57c3d4' })
+  @IsOptional()
+  @IsUUID()
+  id?: string;
+
+  @ApiProperty({ description: 'Identifier of the cart owner', example: '3c76a9da-0c4e-44b6-8d89-2e24125b5c2f' })
+  @IsUUID()
+  userId!: string;
+
+  @ApiProperty({ description: 'Line items comprising the cart', type: [CreateShoppingCartItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateShoppingCartItemDto)
+  items!: CreateShoppingCartItemDto[];
+
+  @ApiPropertyOptional({
+    description: 'Discounts applied to the cart',
+    type: [CreateShoppingCartDiscountDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateShoppingCartDiscountDto)
+  discounts?: CreateShoppingCartDiscountDto[];
+
+  @ApiProperty({ description: 'Subtotal prior to discounts and fees', example: 59.97, minimum: 0 })
+  @Type(() => Number)
+  @Min(0)
+  subtotal!: number;
+
+  @ApiPropertyOptional({ description: 'Total discounts applied', example: 5.0, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(0)
+  discountsTotal?: number;
+
+  @ApiProperty({ description: 'Tax amount applied to the cart', example: 4.80, minimum: 0 })
+  @Type(() => Number)
+  @Min(0)
+  tax!: number;
+
+  @ApiProperty({ description: 'Shipping charges for the cart', example: 7.5, minimum: 0 })
+  @Type(() => Number)
+  @Min(0)
+  shipping!: number;
+
+  @ApiProperty({ description: 'Final total after discounts, tax, and shipping', example: 67.27, minimum: 0 })
+  @Type(() => Number)
+  @Min(0)
+  total!: number;
+
+  @ApiProperty({ description: 'Currency for monetary values', example: 'USD', pattern: '^[A-Z]{3}$' })
+  @Matches(/^[A-Z]{3}$/)
+  @IsString()
+  currency!: string;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp when the cart was created', example: '2025-09-30T23:31:16.000Z' })
+  @IsOptional()
+  @IsString()
+  createdAt?: string;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp when the cart was last updated', example: '2025-09-30T23:31:16.000Z' })
+  @IsOptional()
+  @IsString()
+  updatedAt?: string;
+}
+
+export class UpdateShoppingCartDto extends PartialType(CreateShoppingCartDto) {
+  @ApiPropertyOptional({ description: 'Line items comprising the cart', type: [UpdateShoppingCartItemDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateShoppingCartItemDto)
+  override items?: UpdateShoppingCartItemDto[];
+
+  @ApiPropertyOptional({ description: 'Discounts applied to the cart', type: [UpdateShoppingCartDiscountDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateShoppingCartDiscountDto)
+  override discounts?: UpdateShoppingCartDiscountDto[];
+}
+
+export class ResponseShoppingCartDto {
+  @ApiResponseProperty({ description: 'Identifier for the cart', example: '3d5e67a5-0df5-4c08-9ad0-5f7c1c57c3d4' })
+  id!: string;
+
+  @ApiResponseProperty({ description: 'Identifier of the cart owner', example: '3c76a9da-0c4e-44b6-8d89-2e24125b5c2f' })
+  userId!: string;
+
+  @ApiResponseProperty({ description: 'Line items comprising the cart', type: [ShoppingCartItemDto] })
+  items!: ShoppingCartItemDto[];
+
+  @ApiResponseProperty({ description: 'Discounts applied to the cart', type: [ShoppingCartDiscountDto] })
+  discounts!: ShoppingCartDiscountDto[];
+
+  @ApiResponseProperty({ description: 'Subtotal prior to discounts and fees', example: 59.97 })
+  subtotal!: number;
+
+  @ApiResponseProperty({ description: 'Aggregate discount amount', example: 5.0 })
+  discountsTotal!: number;
+
+  @ApiResponseProperty({ description: 'Tax amount applied to the cart', example: 4.8 })
+  tax!: number;
+
+  @ApiResponseProperty({ description: 'Shipping charges for the cart', example: 7.5 })
+  shipping!: number;
+
+  @ApiResponseProperty({ description: 'Final total after discounts, tax, and shipping', example: 67.27 })
+  total!: number;
+
+  @ApiResponseProperty({ description: 'Currency for monetary values', example: 'USD' })
+  currency!: string;
+
+  @ApiResponseProperty({ description: 'Timestamp when the cart was created', example: '2025-09-30T23:31:16.000Z' })
+  createdAt!: string;
+
+  @ApiResponseProperty({ description: 'Timestamp when the cart was last updated', example: '2025-09-30T23:41:16.000Z' })
+  updatedAt!: string;
+}

--- a/api/src/shopping-cart/entities/shopping-cart-discount.entity.ts
+++ b/api/src/shopping-cart/entities/shopping-cart-discount.entity.ts
@@ -1,0 +1,42 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/entities/shopping-cart-discount.entity.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartDiscountEntity
+ * Description: TypeORM entity modeling discounts applied to shopping carts with uniqueness constraints per code.
+ */
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { ColumnNumericTransformer } from '../../common/database/column-numeric.transformer';
+import { ShoppingCartEntity } from './shopping-cart.entity';
+
+@Entity({ name: 'shopping_cart_discount', schema: 'shopping_cart' })
+@Index('ix_shopping_cart_discount_cart_id', ['cartId'])
+@Index('ux_shopping_cart_discount_code', ['cartId', 'code'], { unique: true, where: 'code IS NOT NULL' })
+export class ShoppingCartDiscountEntity {
+  @PrimaryGeneratedColumn('increment', { name: 'discount_id', type: 'integer' })
+  discountId!: number;
+
+  @Column('uuid', { name: 'cart_id' })
+  cartId!: string;
+
+  @Column('varchar', { length: 64, nullable: true })
+  code?: string | null;
+
+  @Column('numeric', {
+    name: 'amount',
+    precision: 12,
+    scale: 2,
+    transformer: new ColumnNumericTransformer(),
+  })
+  amount!: number;
+
+  @ManyToOne(() => ShoppingCartEntity, (cart) => cart.discounts, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'cart_id', referencedColumnName: 'cartId' })
+  cart!: ShoppingCartEntity;
+}

--- a/api/src/shopping-cart/entities/shopping-cart-item.entity.ts
+++ b/api/src/shopping-cart/entities/shopping-cart-item.entity.ts
@@ -1,0 +1,59 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/entities/shopping-cart-item.entity.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartItemEntity
+ * Description: TypeORM entity representing persisted shopping cart line items with product references and totals.
+ */
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { ColumnNumericTransformer } from '../../common/database/column-numeric.transformer';
+import { ShoppingCartEntity } from './shopping-cart.entity';
+
+@Entity({ name: 'shopping_cart_item', schema: 'shopping_cart' })
+@Index('ix_shopping_cart_item_cart_id', ['cartId'])
+@Unique('ux_shopping_cart_item_cart_product', ['cartId', 'productId'])
+export class ShoppingCartItemEntity {
+  @PrimaryGeneratedColumn('increment', { name: 'item_id', type: 'integer' })
+  itemId!: number;
+
+  @Column('uuid', { name: 'cart_id' })
+  cartId!: string;
+
+  @Column('varchar', { name: 'product_id', length: 100 })
+  productId!: string;
+
+  @Column('varchar', { length: 255 })
+  name!: string;
+
+  @Column('integer', { name: 'quantity' })
+  quantity!: number;
+
+  @Column('numeric', {
+    name: 'unit_price',
+    precision: 12,
+    scale: 2,
+    transformer: new ColumnNumericTransformer(),
+  })
+  unitPrice!: number;
+
+  @Column('numeric', {
+    name: 'total_price',
+    precision: 12,
+    scale: 2,
+    transformer: new ColumnNumericTransformer(),
+  })
+  totalPrice!: number;
+
+  @Column('char', { name: 'currency', length: 3, nullable: true })
+  currency?: string | null;
+
+  @ManyToOne(() => ShoppingCartEntity, (cart) => cart.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'cart_id', referencedColumnName: 'cartId' })
+  cart!: ShoppingCartEntity;
+}

--- a/api/src/shopping-cart/entities/shopping-cart.entity.ts
+++ b/api/src/shopping-cart/entities/shopping-cart.entity.ts
@@ -1,0 +1,90 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/entities/shopping-cart.entity.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartEntity
+ * Description: TypeORM aggregate root for persisted shopping cart records with financial totals and relational mapping.
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ColumnNumericTransformer } from '../../common/database/column-numeric.transformer';
+import { ShoppingCartItemEntity } from './shopping-cart-item.entity';
+import { ShoppingCartDiscountEntity } from './shopping-cart-discount.entity';
+
+@Entity({ name: 'shopping_cart', schema: 'shopping_cart' })
+@Unique('ux_shopping_cart_user_id_cart_id', ['userId', 'cartId'])
+@Index('ix_shopping_cart_user_id', ['userId'])
+export class ShoppingCartEntity {
+  @PrimaryGeneratedColumn('uuid', { name: 'cart_id' })
+  cartId!: string;
+
+  @Column('uuid', { name: 'user_id' })
+  userId!: string;
+
+  @Column('numeric', {
+    name: 'subtotal',
+    precision: 12,
+    scale: 2,
+    transformer: new ColumnNumericTransformer(),
+  })
+  subtotal!: number;
+
+  @Column('numeric', {
+    name: 'tax',
+    precision: 12,
+    scale: 2,
+    default: 0,
+    transformer: new ColumnNumericTransformer(),
+  })
+  tax!: number;
+
+  @Column('numeric', {
+    name: 'shipping',
+    precision: 12,
+    scale: 2,
+    default: 0,
+    transformer: new ColumnNumericTransformer(),
+  })
+  shipping!: number;
+
+  @Column('numeric', {
+    name: 'total',
+    precision: 12,
+    scale: 2,
+    transformer: new ColumnNumericTransformer(),
+  })
+  total!: number;
+
+  @Column('char', { name: 'currency', length: 3 })
+  currency!: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @OneToMany(() => ShoppingCartItemEntity, (item) => item.cart, {
+    cascade: true,
+    eager: false,
+  })
+  items!: ShoppingCartItemEntity[];
+
+  @OneToMany(() => ShoppingCartDiscountEntity, (discount) => discount.cart, {
+    cascade: true,
+    eager: false,
+  })
+  discounts!: ShoppingCartDiscountEntity[];
+}

--- a/api/src/shopping-cart/services/shopping-cart.service.ts
+++ b/api/src/shopping-cart/services/shopping-cart.service.ts
@@ -1,0 +1,226 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/services/shopping-cart.service.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartService
+ * Description: Domain service orchestrating transactional CRUD operations for shopping carts and nested relations.
+ */
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource, In, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { plainToInstance } from 'class-transformer';
+import { ShoppingCartEntity } from '../entities/shopping-cart.entity';
+import { ShoppingCartItemEntity } from '../entities/shopping-cart-item.entity';
+import { ShoppingCartDiscountEntity } from '../entities/shopping-cart-discount.entity';
+import {
+  CreateShoppingCartDto,
+  ResponseShoppingCartDto,
+  UpdateShoppingCartDto,
+} from '../dto/shopping-cart.dto';
+
+@Injectable()
+export class ShoppingCartService {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(ShoppingCartEntity)
+    private readonly cartRepository: Repository<ShoppingCartEntity>,
+  ) {}
+
+  async create(dto: CreateShoppingCartDto): Promise<ResponseShoppingCartDto> {
+    return this.dataSource.transaction(async (manager) => {
+      const cart = manager.create(ShoppingCartEntity, {
+        cartId: dto.id,
+        userId: dto.userId,
+        subtotal: dto.subtotal,
+        tax: dto.tax,
+        shipping: dto.shipping,
+        total: dto.total,
+        currency: dto.currency,
+      });
+
+      cart.items = (dto.items ?? []).map((item) =>
+        manager.create(ShoppingCartItemEntity, {
+          cart,
+          productId: item.productId,
+          name: item.name,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+          totalPrice: item.totalPrice ?? item.unitPrice * item.quantity,
+          currency: item.currency ?? dto.currency,
+        }),
+      );
+
+      cart.discounts = (dto.discounts ?? []).map((discount) =>
+        manager.create(ShoppingCartDiscountEntity, {
+          cart,
+          code: discount.code,
+          amount: discount.amount,
+        }),
+      );
+
+      const saved = await manager.save(cart);
+      return this.toResponse(
+        await manager.findOneOrFail(ShoppingCartEntity, {
+          where: { cartId: saved.cartId },
+          relations: ['items', 'discounts'],
+        }),
+      );
+    });
+  }
+
+  async findAll(): Promise<ResponseShoppingCartDto[]> {
+    const carts = await this.cartRepository.find({
+      relations: ['items', 'discounts'],
+      order: { createdAt: 'DESC' },
+    });
+    return carts.map((cart) => this.toResponse(cart));
+  }
+
+  async findOne(id: string): Promise<ResponseShoppingCartDto> {
+    const cart = await this.cartRepository.findOne({
+      where: { cartId: id },
+      relations: ['items', 'discounts'],
+    });
+
+    if (!cart) {
+      throw new NotFoundException(`Shopping cart ${id} not found`);
+    }
+
+    return this.toResponse(cart);
+  }
+
+  async update(id: string, dto: UpdateShoppingCartDto): Promise<ResponseShoppingCartDto> {
+    return this.dataSource.transaction(async (manager) => {
+      const cart = await manager.findOne(ShoppingCartEntity, {
+        where: { cartId: id },
+        relations: ['items', 'discounts'],
+      });
+
+      if (!cart) {
+        throw new NotFoundException(`Shopping cart ${id} not found`);
+      }
+
+      if (dto.userId !== undefined) {
+        cart.userId = dto.userId;
+      }
+      if (dto.subtotal !== undefined) {
+        cart.subtotal = dto.subtotal;
+      }
+      if (dto.tax !== undefined) {
+        cart.tax = dto.tax;
+      }
+      if (dto.shipping !== undefined) {
+        cart.shipping = dto.shipping;
+      }
+      if (dto.total !== undefined) {
+        cart.total = dto.total;
+      }
+      if (dto.currency !== undefined) {
+        cart.currency = dto.currency;
+      }
+
+      if (dto.items) {
+        await manager.delete(ShoppingCartItemEntity, { cartId: id });
+        cart.items = dto.items.map((item) =>
+          manager.create(ShoppingCartItemEntity, {
+            cart,
+            productId: item.productId!,
+            name: item.name!,
+            quantity: item.quantity!,
+            unitPrice: item.unitPrice!,
+            totalPrice:
+              item.totalPrice !== undefined
+                ? item.totalPrice
+                : item.unitPrice! * item.quantity!,
+            currency: item.currency ?? cart.currency,
+          }),
+        );
+      }
+
+      if (dto.discounts) {
+        await manager.delete(ShoppingCartDiscountEntity, { cartId: id });
+        cart.discounts = dto.discounts.map((discount) =>
+          manager.create(ShoppingCartDiscountEntity, {
+            cart,
+            code: discount.code,
+            amount: discount.amount ?? 0,
+          }),
+        );
+      }
+
+      const saved = await manager.save(cart);
+      return this.toResponse(
+        await manager.findOneOrFail(ShoppingCartEntity, {
+          where: { cartId: saved.cartId },
+          relations: ['items', 'discounts'],
+        }),
+      );
+    });
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      const result = await manager.delete(ShoppingCartEntity, { cartId: id });
+      if (result.affected === 0) {
+        throw new NotFoundException(`Shopping cart ${id} not found`);
+      }
+    });
+  }
+
+  async clearAll(): Promise<void> {
+    const carts = await this.cartRepository.find({ select: ['cartId'] });
+    if (carts.length === 0) {
+      return;
+    }
+    const ids = carts.map((cart) => cart.cartId);
+    await this.dataSource.transaction(async (manager) => {
+      await manager.delete(ShoppingCartDiscountEntity, { cartId: In(ids) });
+      await manager.delete(ShoppingCartItemEntity, { cartId: In(ids) });
+      await manager.delete(ShoppingCartEntity, { cartId: In(ids) });
+    });
+  }
+
+  private toResponse(entity: ShoppingCartEntity): ResponseShoppingCartDto {
+    const items = [...(entity.items ?? [])];
+    const discounts = [...(entity.discounts ?? [])];
+    const discountsTotal = discounts.reduce((sum, discount) => sum + discount.amount, 0);
+    return plainToInstance(
+      ResponseShoppingCartDto,
+      {
+        id: entity.cartId,
+        userId: entity.userId,
+        items: items
+          .sort((a, b) => a.itemId - b.itemId)
+          .map((item) => ({
+            itemId: item.itemId,
+            productId: item.productId,
+            name: item.name,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            totalPrice: item.totalPrice,
+            currency: item.currency,
+          })),
+        discounts: discounts
+          .sort((a, b) => a.discountId - b.discountId)
+          .map((discount) => ({
+            discountId: discount.discountId,
+            code: discount.code,
+            amount: discount.amount,
+          })),
+        subtotal: entity.subtotal,
+        discountsTotal,
+        tax: entity.tax,
+        shipping: entity.shipping,
+        total: entity.total,
+        currency: entity.currency,
+        createdAt: entity.createdAt.toISOString(),
+        updatedAt: entity.updatedAt.toISOString(),
+      },
+      { enableImplicitConversion: true },
+    );
+  }
+}

--- a/api/src/shopping-cart/shopping-cart.controller.ts
+++ b/api/src/shopping-cart/shopping-cart.controller.ts
@@ -1,0 +1,97 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/shopping-cart.controller.ts
+ * Version: 0.1.0
+ * Turns: 4
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartController
+ * Description: REST controller exposing CRUD operations for shopping cart aggregates with OpenAPI metadata.
+ */
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiExtraModels,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ShoppingCartService } from './services/shopping-cart.service';
+import {
+  CreateShoppingCartDto,
+  ResponseShoppingCartDto,
+  UpdateShoppingCartDto,
+} from './dto/shopping-cart.dto';
+import { ProblemDetail } from '../common/http/problem-detail';
+
+@ApiTags('ShoppingCart')
+@ApiExtraModels(ProblemDetail)
+@Controller('shopping-cart')
+export class ShoppingCartController {
+  constructor(private readonly shoppingCartService: ShoppingCartService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all shopping carts' })
+  @ApiOkResponse({ type: [ResponseShoppingCartDto] })
+  async list(): Promise<ResponseShoppingCartDto[]> {
+    return this.shoppingCartService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Fetch a shopping cart by identifier' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiOkResponse({ type: ResponseShoppingCartDto })
+  @ApiNotFoundResponse({ description: 'Shopping cart not found', type: ProblemDetail })
+  async get(@Param('id', new ParseUUIDPipe()) id: string): Promise<ResponseShoppingCartDto> {
+    return this.shoppingCartService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new shopping cart' })
+  @ApiCreatedResponse({ type: ResponseShoppingCartDto })
+  @ApiBadRequestResponse({ description: 'Payload validation failed', type: ProblemDetail })
+  @ApiBody({ type: CreateShoppingCartDto })
+  async create(@Body() dto: CreateShoppingCartDto): Promise<ResponseShoppingCartDto> {
+    return this.shoppingCartService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update an existing shopping cart' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiOkResponse({ type: ResponseShoppingCartDto })
+  @ApiBadRequestResponse({ description: 'Payload validation failed', type: ProblemDetail })
+  @ApiNotFoundResponse({ description: 'Shopping cart not found', type: ProblemDetail })
+  async update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateShoppingCartDto,
+  ): Promise<ResponseShoppingCartDto> {
+    return this.shoppingCartService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a shopping cart' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiNoContentResponse({ description: 'Cart removed successfully' })
+  @ApiNotFoundResponse({ description: 'Shopping cart not found', type: ProblemDetail })
+  async delete(@Param('id', new ParseUUIDPipe()) id: string): Promise<void> {
+    await this.shoppingCartService.remove(id);
+  }
+}

--- a/api/src/shopping-cart/shopping-cart.module.ts
+++ b/api/src/shopping-cart/shopping-cart.module.ts
@@ -1,0 +1,28 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: shopping-cart/shopping-cart.module.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Exports: ShoppingCartModule
+ * Description: Feature module bundling shopping cart entities, service, and controller registration.
+ */
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ShoppingCartEntity } from './entities/shopping-cart.entity';
+import { ShoppingCartItemEntity } from './entities/shopping-cart-item.entity';
+import { ShoppingCartDiscountEntity } from './entities/shopping-cart-discount.entity';
+import { ShoppingCartService } from './services/shopping-cart.service';
+import { ShoppingCartController } from './shopping-cart.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ShoppingCartEntity, ShoppingCartItemEntity, ShoppingCartDiscountEntity]),
+  ],
+  controllers: [ShoppingCartController],
+  providers: [ShoppingCartService],
+  exports: [ShoppingCartService],
+})
+export class ShoppingCartModule {}

--- a/api/test/e2e/shopping-cart.e2e-spec.ts
+++ b/api/test/e2e/shopping-cart.e2e-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * App: Shopping Cart
+ * Package: api
+ * File: test/e2e/shopping-cart.e2e-spec.ts
+ * Version: 0.1.0
+ * Turns: 4
+ * Author: Codex Agent
+ * Date: 2025-09-30T23:55:39Z
+ * Description: Supertest-driven end-to-end coverage for shopping cart CRUD flows and OpenAPI discovery.
+ */
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+import { AppDataSource } from '../../src/database/data-source';
+import { HttpExceptionFilter } from '../../src/common/http/http-exception.filter';
+import { JsonLogger } from '../../src/common/logging/json-logger.service';
+import { LoggingInterceptor } from '../../src/common/logging/logging.interceptor';
+
+describe('ShoppingCartController (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = AppDataSource;
+    if (!dataSource.isInitialized) {
+      await dataSource.initialize();
+      await dataSource.runMigrations();
+    }
+
+    const moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    const logger = app.get(JsonLogger);
+    logger.setLogLevels(['error']);
+    app.useLogger(logger);
+    app.useGlobalFilters(app.get(HttpExceptionFilter));
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: true,
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      }),
+    );
+    app.useGlobalInterceptors(app.get(LoggingInterceptor));
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    await dataSource.query('TRUNCATE TABLE shopping_cart.shopping_cart_discount RESTART IDENTITY CASCADE');
+    await dataSource.query('TRUNCATE TABLE shopping_cart.shopping_cart_item RESTART IDENTITY CASCADE');
+    await dataSource.query('TRUNCATE TABLE shopping_cart.shopping_cart RESTART IDENTITY CASCADE');
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it('creates, reads, updates, and deletes a shopping cart', async () => {
+    const createResponse = await request(app.getHttpServer())
+      .post('/shopping-cart')
+      .send({
+        userId: 'e4fb3c2a-8935-4431-90bf-6fb6c803a2e9',
+        items: [
+          {
+            productId: 'SKU-777',
+            name: 'Mechanical Keyboard',
+            quantity: 1,
+            unitPrice: 129.99,
+            currency: 'USD',
+          },
+        ],
+        discounts: [
+          {
+            code: 'WELCOME10',
+            amount: 10,
+          },
+        ],
+        subtotal: 129.99,
+        tax: 11.7,
+        shipping: 0,
+        total: 131.69,
+        currency: 'USD',
+      })
+      .expect(201);
+
+    const cartId = createResponse.body.id;
+    expect(createResponse.body.items).toHaveLength(1);
+    expect(createResponse.body.discounts).toHaveLength(1);
+
+    const listResponse = await request(app.getHttpServer())
+      .get('/shopping-cart')
+      .expect(200);
+    expect(Array.isArray(listResponse.body)).toBe(true);
+    expect(listResponse.body[0].id).toEqual(cartId);
+
+    await request(app.getHttpServer())
+      .put(`/shopping-cart/${cartId}`)
+      .send({
+        tax: 12.0,
+        total: 132.0,
+      })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.tax).toBeCloseTo(12.0);
+        expect(body.total).toBeCloseTo(132.0);
+      });
+
+    await request(app.getHttpServer()).delete(`/shopping-cart/${cartId}`).expect(204);
+    await request(app.getHttpServer()).get(`/shopping-cart/${cartId}`).expect(404);
+  });
+
+  it('rejects invalid payloads with problem detail envelope', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/shopping-cart')
+      .send({
+        userId: 'not-a-uuid',
+        items: [],
+        subtotal: -1,
+        tax: -1,
+        shipping: -1,
+        total: -1,
+        currency: 'usd',
+        unexpected: true,
+      })
+      .expect(422);
+
+    expect(response.body).toMatchObject({
+      statusCode: 422,
+      error: 'Unprocessable Entity',
+      path: '/shopping-cart',
+    });
+    expect(Array.isArray(response.body.message)).toBe(true);
+  });
+
+  it('returns 404 problem detail for unknown route', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/shopping-cart/non-existent-id')
+      .expect(404);
+
+    expect(response.body).toMatchObject({
+      statusCode: 404,
+      error: 'Not Found',
+    });
+  });
+
+  it('exposes OpenAPI contract with shopping cart paths', async () => {
+    const response = await request(app.getHttpServer()).get('/api/openapi.json').expect(200);
+    expect(response.body.paths['/shopping-cart']).toBeDefined();
+    expect(response.body.paths['/shopping-cart/{id}']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- model the shopping cart domain with TypeORM entities, data source, and migration support
- wire NestJS configuration and scripts for database connectivity and migrations
- implement shopping cart DTOs, service, controller, and global error handling with Swagger documentation
- add Supertest e2e coverage, HTTP smoke tests, and record turn artifacts for worklog

## Testing
- not run (Postgres service is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc6b7d0100832d917f3bf44fc422c4